### PR TITLE
Fix resort selection crash and region marker visibility

### DIFF
--- a/src/app/components/MapControls.jsx
+++ b/src/app/components/MapControls.jsx
@@ -164,6 +164,7 @@ export default function MapControls({
                     const zoom = window.innerWidth <= 768 ? region.zoom - 0.75 : region.zoom;
                     stopSpin();
                     useMapStore.getState().setLastRegion({ lng: region.lng, lat: region.lat, zoom: region.zoom });
+                    useMapStore.getState().setCurrentZoom(zoom);
                     mapRef.current?.flyTo({ center: [region.lng, region.lat], zoom, pitch: 0, bearing: 0 });
                     setRegionsOpen(false);
                   }}

--- a/src/app/hooks/useMapNavigation.js
+++ b/src/app/hooks/useMapNavigation.js
@@ -86,6 +86,9 @@ export default function useMapNavigation(mapRef, stopSpin) {
       setLastRegion({ lng: region.lng, lat: region.lat, zoom: region.zoom });
       const zoom =
         window.innerWidth <= 768 ? region.zoom - 0.5 : region.zoom;
+      // Immediately update currentZoom so region markers hide without
+      // waiting for the flyTo animation's zoom events to propagate.
+      useMapStore.getState().setCurrentZoom(zoom);
       map.flyTo({
         center: [region.lng, region.lat],
         zoom,

--- a/src/app/hooks/useResortWeather.js
+++ b/src/app/hooks/useResortWeather.js
@@ -152,6 +152,12 @@ export function useBatchSnowData(resorts, enabled = true, visibleSlugs = null) {
     })),
   });
 
+  // Stable key from query data content — avoids infinite re-render loops
+  // caused by useQueries returning a new array reference every render.
+  const queriesDataKey = queries
+    .map((q) => (q.data ? q.data.length : 'p'))
+    .join(',');
+
   // Merge prefetch + live data (live overrides prefetch)
   const allData = useMemo(() => {
     const map = new Map();
@@ -173,7 +179,8 @@ export function useBatchSnowData(resorts, enabled = true, visibleSlugs = null) {
     }
 
     return Array.from(map.values());
-  }, [prefetchData, queries]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefetchData, queriesDataKey]);
 
   const isLoading = !prefetchLoaded || queries.some((q) => q.isLoading);
 


### PR DESCRIPTION
## Summary
- **Fix max update depth exceeded crash**: Stabilize `useBatchSnowData`'s `allData` useMemo by replacing the unstable `queries` array ref (new every render from `useQueries`) with a content-derived `queriesDataKey` string, breaking the infinite re-render loop triggered on resort selection.
- **Fix region markers not disappearing**: Immediately set `currentZoom` to the target zoom when clicking a region (both from `RegionMarkers` and the Regions dropdown) so markers hide instantly instead of waiting for `flyTo` animation zoom events to propagate through React state.

## Test plan
- [ ] Select a resort from the map — should not crash with "max update depth exceeded"
- [ ] Select a resort from the sidebar/carousel — should not crash
- [ ] Click Alps region marker — region markers should disappear immediately
- [ ] Click any region from the Regions dropdown — markers should hide instantly
- [ ] Verify snow data still loads correctly after stabilization fix
- [ ] Verify zoom events still update `currentZoom` during normal map interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)