### PR TITLE
Fix: viewport query race condition + region label persistence

### DIFF
--- a/src/app/components/MapExplore.jsx
+++ b/src/app/components/MapExplore.jsx
@@ -38,7 +38,7 @@ export function MapExplore({ resortCollection }) {
   const setPisteData = useMapStore((s) => s.setPisteData);
 
   // Hooks — called unconditionally before any returns
-  const { queryViewport, onMapReady } = useViewportResorts(mapRef);
+  const { queryViewport, bindMapEvents } = useViewportResorts(mapRef);
   const { spinning, setSpinning, spinningRef, setUserStopped, stopSpin } = useGlobeSpin(mapRef);
   const { flyToResort, resetView, flyToRegion, onRegionClick, clickedFromMapRef } =
     useMapNavigation(mapRef, stopSpin);
@@ -113,7 +113,9 @@ export function MapExplore({ resortCollection }) {
       if (slug && !seen.has(slug)) { seen.add(slug); slugs.push(slug); }
     });
     setVisibleSlugs(slugs);
-  }, [spinningRef, setVisibleSlugs]);
+    // Also trigger viewport query to keep results in sync
+    queryViewport();
+  }, [spinningRef, setVisibleSlugs, queryViewport]);
 
   // Click on resort
   const onClick = useCallback(
@@ -145,8 +147,8 @@ export function MapExplore({ resortCollection }) {
 
   const handleMapLoad = useCallback(() => {
     onMapLoad();
-    onMapReady();
-  }, [onMapLoad, onMapReady]);
+    bindMapEvents();
+  }, [onMapLoad, bindMapEvents]);
 
   const interactiveLayerIds = useMemo(() => ['resort-dots', 'resort-markers'], []);
   const currentZoom = useMapStore((s) => s.currentZoom);


### PR DESCRIPTION
## Root Causes

**Resorts flash then disappear:** `queryRenderedFeatures` was running on `moveend` before Mapbox finished rendering tiles at the new zoom level. Query returned empty → `setRenderedResorts([])` → resorts vanish.

**Region labels persist:** The `zoom` event listener was registered inside a `useEffect` gated by `useState(mapReady)`. React's async state update meant the listener attached *after* the first flyTo animation started, missing the zoom transition.

## Fixes

1. **`bindMapEvents()` replaces `onMapReady()`** — event listeners now attach synchronously in the `onLoad` callback. No useState race.

2. **`idle` event listener** — Mapbox `idle` fires after all tiles are loaded and rendered. This is the reliable moment to run `queryRenderedFeatures`. Added alongside `moveend` for belt-and-suspenders.

3. **Retry logic** — if query returns 0 results at a valid zoom (≥5), retries after 500ms. Handles the case where idle hasn't fired yet.

4. **Removed debounce** — `idle` is already naturally debounced by Mapbox. The 150ms setTimeout was adding latency without benefit.

## Files Changed
- `useViewportResorts.js` — core fix
- `MapExplore.jsx` — updated to use `bindMapEvents`, added `queryViewport` to `onMoveEnd`
