### PR TITLE
fix: nav state machine - stop results flickering, fix back button, fix control overlap

### DIFF
--- a/src/app/components/MapControls.jsx
+++ b/src/app/components/MapControls.jsx
@@ -248,7 +248,7 @@ export default function MapControls({
 
       {/* ── Back button: mid-left on mobile (clear of carousel + search), bottom-left on desktop ── */}
       {showBackButton && (
-        <div className="pointer-events-auto absolute left-3 bottom-[10rem] sm:bottom-3 sm:left-[calc(3rem+64px)]">
+        <div className="pointer-events-auto absolute left-3 bottom-[12.5rem] sm:bottom-3 sm:left-[calc(3rem+64px)]">
           <button
             onClick={handleBack}
             className="flex items-center gap-1 rounded-full min-h-[44px] px-4 py-2.5 text-xs font-semibold backdrop-blur-md transition-all sm:min-h-0 sm:px-3 sm:py-1.5"
@@ -266,7 +266,7 @@ export default function MapControls({
 
       {/* ── Bottom-right: Satellite toggle (detail zoom only) ── */}
       {nav?.isResort && (
-        <div className="pointer-events-auto absolute bottom-[11.5rem] right-3 sm:bottom-[3.5rem]">
+        <div className="pointer-events-auto absolute bottom-[12.5rem] right-3 sm:bottom-[8rem]">
           <button
             onClick={() => useMapStore.getState().toggleSatellite()}
             className={`flex items-center justify-center rounded-full w-11 h-11 sm:w-9 sm:h-9 text-base sm:text-sm backdrop-blur-sm transition-all ${
@@ -285,7 +285,7 @@ export default function MapControls({
       )}
 
       {/* ── Bottom-right: Auto-rotate toggle (above Mapbox zoom controls) ── */}
-      <div className="pointer-events-auto absolute bottom-[8rem] right-3 sm:bottom-[4.5rem]">
+      <div className="pointer-events-auto absolute bottom-[9rem] right-3 sm:bottom-[5rem]">
         <button
           onClick={handleAutoRotate}
           className={`flex items-center justify-center rounded-full w-11 h-11 sm:w-9 sm:h-9 text-base sm:text-sm backdrop-blur-sm transition-all ${
@@ -303,7 +303,7 @@ export default function MapControls({
       </div>
 
       {/* ── Bottom-left: Base map switcher ── */}
-      <div className="pointer-events-auto absolute bottom-[8rem] left-3 sm:bottom-3">
+      <div className="pointer-events-auto absolute bottom-[9rem] left-3 sm:bottom-3">
         <BaseMapSwitcher
           activeStyle={mapStyleKey}
           onStyleChange={(key) => {

--- a/src/app/components/MapExplore.jsx
+++ b/src/app/components/MapExplore.jsx
@@ -190,7 +190,7 @@ export function MapExplore({ resortCollection, nav }) {
 
         <NavigationControl position="bottom-right" showCompass={false} />
         <GeolocateControl
-          position="top-left"
+          position="top-right"
           positionOptions={{ enableHighAccuracy: true }}
           trackUserLocation={false}
           showUserHeading={true}

--- a/src/app/hooks/useMapNavigation.js
+++ b/src/app/hooks/useMapNavigation.js
@@ -30,6 +30,8 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
 
   const lastFlewToRef = useRef(null);
   const clickedFromMapRef = useRef(false);
+  const navRef = useRef(nav);
+  navRef.current = nav;
 
   // Fly to resort in 3D
   const flyToResort = useCallback(
@@ -137,10 +139,12 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
     lastFlewToRef.current = null;
   }, [mapRef, lastRegion, setSelectedResort, setIsResortView, nav]);
 
-  // Back-to-region triggered from cards
+  // Back-to-region triggered from cards (ExpandedDetailCard "Back to Region" button)
   useEffect(() => {
     if (pendingBackToRegion) {
       clearPendingBackToRegion();
+      // Update URL nav state — go back from resort to region (or region to globe)
+      if (navRef.current) navRef.current.goBack();
       const map = mapRef.current;
       if (!map) return;
       let target = lastRegion;

--- a/src/app/hooks/useViewportResorts.js
+++ b/src/app/hooks/useViewportResorts.js
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useCallback } from "react";
 import useMapStore from "../store/useMapStore";
-import { RESORT_MIN } from "../constants/zoom";
 
 /**
  * useViewportResorts — computes visible resorts from map bounds + GeoJSON data.
@@ -29,13 +28,10 @@ export default function useViewportResorts(mapRef, resorts) {
     const zoom = map.getZoom();
     setCurrentZoom(zoom);
 
-    // At globe zoom, clear results — user should pick a region
-    if (zoom < RESORT_MIN) {
-      setRenderedResorts([]);
-      return;
-    }
-
     // Get map bounds and filter resorts by geography
+    // NOTE: No zoom-based clearing here. Nav state (useNavState) controls
+    // whether results are shown in page.js and MobileCarousel. Clearing
+    // here caused flickering during flyTo animations.
     const bounds = map.getBounds();
     if (!bounds) {
       setRenderedResorts([]);


### PR DESCRIPTION
## Problem
Results were flickering/disappearing when navigating to a region. Controls overlapped on mobile. Back button didn't sync URL params.

## Root Causes
1. **Results flickering**: `useViewportResorts.queryViewport()` cleared results when `zoom < RESORT_MIN (5)`. During `flyTo` animations from globe→region, the camera passes through low zoom values, triggering the clear. The throttled `move` handler re-queries at 100ms intervals, causing visible flicker.

2. **Back button URL desync**: The `pendingBackToRegion` effect (triggered by card 'Back to Region' button) flew the camera back but never called `nav.goBack()`, leaving URL params stale (`?resort=...` still set).

3. **Controls overlap**: GeolocateControl at `top-left` overlapped Regions dropdown. Mobile bottom controls (back button, auto-rotate, base map, satellite) stacked on top of each other.

## Fixes
- **Remove zoom-based clearing in useViewportResorts** — nav state (`useNavState`/nuqs) already controls result visibility in `page.js` (`nav.isGlobe → return []`) and `MobileCarousel` (`nav.isGlobe → return null`). The viewport query should always compute visible resorts; the UI layer decides whether to show them.

- **Add `nav.goBack()` to pendingBackToRegion effect** — uses a ref to avoid adding `nav` to effect deps. Now URL params correctly transition from `?resort=X` → `?region=Y` when clicking back.

- **Move GeolocateControl to top-right** — no longer overlaps Regions dropdown.

- **Adjust mobile control positions** — spread out vertically to prevent overlap:
  - Back button: `bottom-[12.5rem]`
  - Satellite toggle: `bottom-[12.5rem]` (right side)
  - Auto-rotate: `bottom-[9rem]`
  - Base map: `bottom-[9rem]`

## Testing
- `npm run build` passes
- Nav flow: Globe → Region (results populate immediately, no flicker) → Resort (detail card) → Back (returns to region, URL updates)