### PR TITLE
fix: region labels + stale global results (#86)

### DIFF
--- a/src/app/hooks/useNavState.js
+++ b/src/app/hooks/useNavState.js
@@ -14,8 +14,12 @@ import { useQueryState } from "nuqs";
  * The URL IS the nav state. Camera follows. No zoom-threshold logic needed.
  */
 export default function useNavState() {
-  const [region, setRegion] = useQueryState("region");
-  const [resort, setResort] = useQueryState("resort");
+  const [regionRaw, setRegion] = useQueryState("region");
+  const [resortRaw, setResort] = useQueryState("resort");
+
+  // Normalize empty strings to null (nuqs can return "" instead of null)
+  const region = regionRaw || null;
+  const resort = resortRaw || null;
 
   // Derived view — single source of truth
   const navView = useMemo(() => {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -63,8 +63,17 @@ function AppContent() {
     // At globe view, show nothing — user picks a region first
     if (nav.isGlobe) return [];
 
-    return filteredResorts.filter((r) => activePasses.has(r.properties?.pass));
-  }, [filteredResorts, resorts, activePasses, searchQuery, nav.isGlobe]);
+    // Filter viewport resorts by active passes + current region
+    // Region filter prevents stale global results from showing during flyTo
+    // (viewport bounds at globe zoom contain the entire world)
+    return filteredResorts.filter((r) => {
+      if (!activePasses.has(r.properties?.pass)) return false;
+      if (nav.region) {
+        return r.properties?.region_id === nav.region;
+      }
+      return true;
+    });
+  }, [filteredResorts, resorts, activePasses, searchQuery, nav.isGlobe, nav.region]);
 
   return (
     <div className="flex h-[calc(100dvh-3rem)] flex-col overflow-hidden sm:h-[calc(100dvh-3.5rem)]">


### PR DESCRIPTION
## Bug 1: Region labels missing on initial load

`useQueryState('region')` from nuqs returns `""` (empty string) instead of `null` when no URL params are set. Empty string is truthy, so `navView` computed as `"region"` instead of `"globe"`, causing `RegionMarkers` to return null on page load.

**Fix:** Normalize empty strings to null in `useNavState.js` before deriving nav state.

## Bug 2: Global results override regional viewport-filtered results

At globe zoom, map bounds contain the entire world, so `useViewportResorts` matches ALL resorts. When a user clicks a region, nuqs updates `?region=` immediately but the map hasn't flown yet — `filteredResorts` still contains the global set, causing the results panel to briefly show 4000+ resorts.

**Fix:** Filter `displayedResorts` by `region_id` when in regional view, so only resorts belonging to the active region appear regardless of viewport bounds.

## Files changed
- `src/app/hooks/useNavState.js` — normalize empty string → null
- `src/app/page.js` — add region_id filter to displayedResorts

Build passes ✅