### PR TITLE
fix(#87,#88,#89): Nav polish — remove dup back button, skip globe viewport query, manifest camera

### DIFF
--- a/src/app/components/MapExplore.jsx
+++ b/src/app/components/MapExplore.jsx
@@ -41,7 +41,7 @@ export function MapExplore({ resortCollection, nav }) {
   const setPisteData = useMapStore((s) => s.setPisteData);
 
   // Hooks — called unconditionally before any returns
-  const { queryViewport, bindMapEvents } = useViewportResorts(mapRef, resorts);
+  const { queryViewport, bindMapEvents } = useViewportResorts(mapRef, resorts, nav.navView);
   const { spinning, setSpinning, spinningRef, setUserStopped, stopSpin } = useGlobeSpin(mapRef);
   const { flyToResort, resetView, flyToRegion, onRegionClick, clickedFromMapRef } =
     useMapNavigation(mapRef, stopSpin, nav);

--- a/src/app/components/MobileCarousel.jsx
+++ b/src/app/components/MobileCarousel.jsx
@@ -141,7 +141,7 @@ function MobileSearchBar({ searchQuery, setSearchQuery }) {
   );
 }
 
-function ExpandedMobileCard({ resort, onBack }) {
+function ExpandedMobileCard({ resort }) {
   const snowBySlug = useMapStore((s) => s.snowBySlug);
   const webcamBySlug = useMapStore((s) => s.webcamBySlug);
   const pisteData = useMapStore((s) => s.pisteData);
@@ -172,15 +172,6 @@ function ExpandedMobileCard({ resort, onBack }) {
     <div className="snap-center shrink-0 w-full rounded-xl p-3 border border-sky-500/60 ring-1 ring-sky-500/30 bg-slate-900/95 backdrop-blur-xl overflow-y-auto"
       style={{ maxHeight: "calc(50vh - env(safe-area-inset-bottom, 0px))" }}
     >
-      {/* Back button */}
-      {onBack && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onBack(); }}
-          className="flex items-center gap-1 mb-2 text-[11px] text-sky-400 hover:text-sky-300 transition-colors"
-        >
-          <span>‹</span> Back to Region
-        </button>
-      )}
       <div className="flex items-center gap-1.5 mb-1">
         {passLink ? (
           <a href={passLink} target="_blank" rel="noopener noreferrer"
@@ -321,7 +312,7 @@ export function MobileCarousel({ resorts, selectedResort, setSelectedResort, nav
         style={{ WebkitOverflowScrolling: "touch" }}
       >
         {showExpanded && (
-          <ExpandedMobileCard key="expanded-detail" resort={selectedResort} onBack={useMapStore.getState().triggerBackToRegion} />
+          <ExpandedMobileCard key="expanded-detail" resort={selectedResort} />
         )}
         {!selectedResort && sorted?.map((resort) => {
           return (

--- a/src/app/components/ResultsContainer.jsx
+++ b/src/app/components/ResultsContainer.jsx
@@ -55,7 +55,7 @@ function TrailBreakdown({ pisteData }) {
   );
 }
 
-function ExpandedDetailCard({ resort, onClick, onBack }) {
+function ExpandedDetailCard({ resort, onClick }) {
   const snowBySlug = useMapStore((s) => s.snowBySlug);
   const webcamBySlug = useMapStore((s) => s.webcamBySlug);
   const pisteData = useMapStore((s) => s.pisteData);
@@ -80,15 +80,6 @@ function ExpandedDetailCard({ resort, onClick, onBack }) {
       className="w-full rounded-xl p-4 transition-all border border-sky-500/50 ring-1 ring-sky-500/20 backdrop-blur-xl overflow-y-auto"
       style={{ background: "rgba(15,23,42,0.92)" }}
     >
-      {/* Back button */}
-      {onBack && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onBack(); }}
-          className="flex items-center gap-1 mb-3 text-[11px] text-sky-400 hover:text-sky-300 transition-colors"
-        >
-          <span>‹</span> Back to Region
-        </button>
-      )}
       {/* Header */}
       <div className="flex items-center gap-2 mb-1.5">
         {passLink ? (
@@ -378,7 +369,6 @@ export function ResultsContainer({ resorts, setSelectedResort, selectedResort, n
         {selectedResort && (
           <ExpandedDetailCard
             resort={selectedResort}
-            onBack={useMapStore.getState().triggerBackToRegion}
           />
         )}
         {/* Resort list — hidden when a resort is selected */}

--- a/src/app/store/useMapStore.js
+++ b/src/app/store/useMapStore.js
@@ -45,11 +45,6 @@ const useMapStore = create(
       lastRegion: null,
       setLastRegion: (r) => set({ lastRegion: r }),
 
-      // ── Back to region trigger (set by cards, consumed by MapExplore) ──
-      pendingBackToRegion: false,
-      triggerBackToRegion: () => set({ pendingBackToRegion: true, selectedResort: null, isResortView: false }),
-      clearPendingBackToRegion: () => set({ pendingBackToRegion: false }),
-
       // ── Map view (controlled mode for react-map-gl) ──
       viewState: { longitude: -98, latitude: 39, zoom: 1.2, pitch: 0, bearing: 0 },
       setViewState: (vs) => set({ viewState: vs }),


### PR DESCRIPTION
## Changes

### Issue #87: Remove duplicate back button from detail card
- Removed "Back to Region" button from `ExpandedDetailCard` (ResultsContainer) and `ExpandedMobileCard` (MobileCarousel)
- Removed `pendingBackToRegion`, `triggerBackToRegion`, `clearPendingBackToRegion` from Zustand store
- Removed the `pendingBackToRegion` useEffect consumer in `useMapNavigation`
- Users use the MapControls `‹ Region` button instead (single source of truth)

### Issue #88: Skip viewport query at globe zoom
- `useViewportResorts` now accepts `navView` param (via ref for callback stability)
- `queryViewport()` returns early with empty results when `navView === 'globe'`
- Eliminates wasted bounds filtering on 4,107 resorts during globe view

### Issue #89: Back-to-region always uses region manifest camera
- `flyToRegion()` now reads `region_id` from the selected resort's properties
- Looks up exact camera (center + zoom) from `regions.json` manifest
- Applies mobile zoom offset (`-0.5`) matching `onRegionClick` behavior
- Closest-region heuristic only used as fallback when `region_id` is missing
- `lastRegion` retained in Zustand for MapControls back-button visibility only

### Testing
- `npm run build` passes ✅
- 6 files changed, 30 insertions, 75 deletions (net -45 lines)