### PR TITLE
refactor: move region from nuqs URL to Zustand (#92)

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -21,7 +21,7 @@ import resortCollection from "../../assets/resorts.json";
  */
 function AppContent() {
   const resorts = resortCollection.features;
-  const nav = useNavState();
+  const nav = useNavState(resortCollection);
 
   const selectedResort = useMapStore((s) => s.selectedResort);
   const setSelectedResort = useMapStore((s) => s.setSelectedResort);

--- a/src/app/store/useMapStore.js
+++ b/src/app/store/useMapStore.js
@@ -35,6 +35,10 @@ const useMapStore = create(
       showPistes: true,
       togglePistes: () => set((s) => ({ showPistes: !s.showPistes })),
 
+      // ── Nav region (transient — not persisted, clears on refresh = globe view) ──
+      navRegion: null,
+      setNavRegion: (r) => set({ navRegion: r }),
+
       // ── 3D terrain / fly-to state ──
       previousViewState: null,
       setPreviousViewState: (vs) => set({ previousViewState: vs }),


### PR DESCRIPTION
## What

Move `region` from nuqs URL param to Zustand transient state.

## Why

Region is transient navigation state — on refresh, users should always start at globe view. Only `?resort=slug` should be a shareable permalink.

## Changes

- **useNavState.js**: Removed `useQueryState('region')`. Region now read from `useMapStore.navRegion`. Accepts `resortCollection` param to derive region from resort slug on mount.
- **useMapStore.js**: Added `navRegion` / `setNavRegion` (not persisted — clears on refresh).
- **page.js**: Passes `resortCollection` to `useNavState()`.

## URL behavior

| URL | Result |
|-----|--------|
| `/` | Globe view (always on fresh load) |
| `/?resort=big-sky` | Flies to resort, region auto-derived |
| ~~`/?region=alps`~~ | No longer used |

## Testing

- `npm run build` ✅
- Navigation: globe → region → resort → back works via Zustand
- Refresh on `/?resort=big-sky` → derives region, flies to resort