### PR TITLE
fix: resort markers disappear after navigating to resort (#97)

### DIFF
--- a/src/app/components/MapControls.jsx
+++ b/src/app/components/MapControls.jsx
@@ -279,9 +279,9 @@ export default function MapControls({
         )}
       </div>
 
-      {/* ── Back button: mid-left on mobile (clear of carousel + search), bottom-left on desktop ── */}
+      {/* ── Back button: top-left on mobile (below regions+basemap), bottom-left on desktop ── */}
       {showBackButton && (
-        <div className="pointer-events-auto absolute left-3 bottom-[12.5rem] sm:bottom-3 sm:left-[calc(3rem+64px)]">
+        <div className="pointer-events-auto absolute left-3 top-[7.5rem] sm:top-auto sm:bottom-3 sm:left-[calc(3rem+64px)]">
           <button
             onClick={handleBack}
             className="flex items-center gap-1 rounded-full min-h-[44px] px-4 py-2.5 text-xs font-semibold backdrop-blur-md transition-all sm:min-h-0 sm:px-3 sm:py-1.5"

--- a/src/app/components/MapExplore.jsx
+++ b/src/app/components/MapExplore.jsx
@@ -48,7 +48,7 @@ export function MapExplore({ resortCollection, nav }) {
     snowGeoJSON, regionSnowAvg, setVisibleSlugs,
     snowBySlugRef, snowStableKey,
   } = useSnowData(resorts);
-  const { onMapLoad, onStyleData } = useMapSetup(mapRef, resorts);
+  const { onMapLoad, onStyleData } = useMapSetup(mapRef);
 
   // Piste data loading
   useEffect(() => {

--- a/src/app/components/MobileCarousel.jsx
+++ b/src/app/components/MobileCarousel.jsx
@@ -121,7 +121,7 @@ function MobileSearchBar({ searchQuery, setSearchQuery }) {
               onChange={(e) => setSearchQuery(e.target.value)}
               onBlur={() => { if (!searchQuery) setExpanded(false); }}
               placeholder="Search resorts, locations..."
-              className="w-full rounded-full min-h-[44px] pl-10 pr-11 text-[13px] text-white placeholder-slate-500 outline-none bg-transparent tracking-wide"
+              className="w-full rounded-full min-h-[44px] pl-10 pr-11 text-base text-white placeholder-slate-500 outline-none bg-transparent tracking-wide"
             />
             <button
               onClick={() => { setSearchQuery(""); setExpanded(false); }}

--- a/src/app/components/ResultsContainer.jsx
+++ b/src/app/components/ResultsContainer.jsx
@@ -346,7 +346,7 @@ export function ResultsContainer({ resorts, setSelectedResort, selectedResort, n
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search resorts..."
-            className="w-full rounded-xl py-2.5 pl-9 pr-9 text-xs text-white placeholder-slate-500 outline-none transition-colors focus:ring-1 focus:ring-sky-500/40"
+            className="w-full rounded-xl py-2.5 pl-9 pr-9 text-base sm:text-xs text-white placeholder-slate-500 outline-none transition-colors focus:ring-1 focus:ring-sky-500/40"
             style={{ background: "rgba(255,255,255,0.08)", border: "1px solid rgba(255,255,255,0.12)" }}
           />
           {searchQuery && (

--- a/src/app/hooks/useMapSetup.js
+++ b/src/app/hooks/useMapSetup.js
@@ -3,11 +3,86 @@
 import { useCallback } from "react";
 import useMapStore from "../store/useMapStore";
 
+const MARKER_SIZE = 32;
+
+function createMarkerImage(drawFn) {
+  const canvas = document.createElement("canvas");
+  canvas.width = MARKER_SIZE;
+  canvas.height = MARKER_SIZE;
+  const ctx = canvas.getContext("2d");
+  drawFn(ctx, MARKER_SIZE);
+  return ctx.getImageData(0, 0, MARKER_SIZE, MARKER_SIZE);
+}
+
 /**
- * useMapSetup — onMapLoad (marker images + fog) and onStyleData (re-apply fog).
+ * Ensure all SDF marker icons exist on the map.
+ * Safe to call multiple times — skips icons that already exist.
  */
-export default function useMapSetup(mapRef, resorts) {
-  const setRenderedResorts = useMapStore((s) => s.setRenderedResorts);
+function ensureMarkerIcons(map) {
+  if (!map || !map.hasImage || !map.addImage) return;
+
+  const icons = {
+    "marker-ikon": (ctx, s) => {
+      ctx.beginPath();
+      ctx.arc(s / 2, s / 2, s / 2 - 2, 0, Math.PI * 2);
+      ctx.fillStyle = "white";
+      ctx.fill();
+    },
+    "marker-epic": (ctx, s) => {
+      const cx = s / 2, cy = s / 2, r = s / 2 - 2;
+      ctx.beginPath();
+      ctx.moveTo(cx, cy - r);
+      ctx.lineTo(cx + r, cy);
+      ctx.lineTo(cx, cy + r);
+      ctx.lineTo(cx - r, cy);
+      ctx.closePath();
+      ctx.fillStyle = "white";
+      ctx.fill();
+    },
+    "marker-mc": (ctx, s) => {
+      const cx = s / 2, r = s / 2 - 2;
+      ctx.beginPath();
+      ctx.moveTo(cx, 2);
+      ctx.lineTo(cx + r, s - 2);
+      ctx.lineTo(cx - r, s - 2);
+      ctx.closePath();
+      ctx.fillStyle = "white";
+      ctx.fill();
+    },
+    "marker-indy": (ctx, s) => {
+      const cx = s / 2, cy = s / 2, outerR = s / 2 - 2, innerR = outerR * 0.4;
+      ctx.beginPath();
+      for (let i = 0; i < 10; i++) {
+        const r = i % 2 === 0 ? outerR : innerR;
+        const angle = (Math.PI / 2) * -1 + (Math.PI / 5) * i;
+        const x = cx + Math.cos(angle) * r;
+        const y = cy + Math.sin(angle) * r;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.fillStyle = "white";
+      ctx.fill();
+    },
+    "marker-independent": (ctx, s) => {
+      ctx.beginPath();
+      ctx.arc(s / 2, s / 2, s / 4, 0, Math.PI * 2);
+      ctx.fillStyle = "white";
+      ctx.fill();
+    },
+  };
+
+  for (const [name, drawFn] of Object.entries(icons)) {
+    if (!map.hasImage(name)) {
+      map.addImage(name, createMarkerImage(drawFn), { sdf: true });
+    }
+  }
+}
+
+/**
+ * useMapSetup — onMapLoad (marker images + fog) and onStyleData (re-apply fog + icons).
+ */
+export default function useMapSetup(mapRef) {
   const mapStyleKey = useMapStore((s) => s.mapStyleKey);
 
   const onMapLoad = useCallback(() => {
@@ -15,93 +90,7 @@ export default function useMapSetup(mapRef, resorts) {
     if (!mapWrapper) return;
     const map = mapWrapper.getMap ? mapWrapper.getMap() : mapWrapper;
 
-    const size = 32;
-    const createMarkerImage = (drawFn) => {
-      const canvas = document.createElement("canvas");
-      canvas.width = size;
-      canvas.height = size;
-      const ctx = canvas.getContext("2d");
-      drawFn(ctx, size);
-      return ctx.getImageData(0, 0, size, size);
-    };
-
-    // Circle (Ikon)
-    map.addImage(
-      "marker-ikon",
-      createMarkerImage((ctx, s) => {
-        ctx.beginPath();
-        ctx.arc(s / 2, s / 2, s / 2 - 2, 0, Math.PI * 2);
-        ctx.fillStyle = "white";
-        ctx.fill();
-      }),
-      { sdf: true }
-    );
-
-    // Diamond (Epic)
-    map.addImage(
-      "marker-epic",
-      createMarkerImage((ctx, s) => {
-        const cx = s / 2, cy = s / 2, r = s / 2 - 2;
-        ctx.beginPath();
-        ctx.moveTo(cx, cy - r);
-        ctx.lineTo(cx + r, cy);
-        ctx.lineTo(cx, cy + r);
-        ctx.lineTo(cx - r, cy);
-        ctx.closePath();
-        ctx.fillStyle = "white";
-        ctx.fill();
-      }),
-      { sdf: true }
-    );
-
-    // Triangle (MC)
-    map.addImage(
-      "marker-mc",
-      createMarkerImage((ctx, s) => {
-        const cx = s / 2, r = s / 2 - 2;
-        ctx.beginPath();
-        ctx.moveTo(cx, 2);
-        ctx.lineTo(cx + r, s - 2);
-        ctx.lineTo(cx - r, s - 2);
-        ctx.closePath();
-        ctx.fillStyle = "white";
-        ctx.fill();
-      }),
-      { sdf: true }
-    );
-
-    // Star (Indy)
-    map.addImage(
-      "marker-indy",
-      createMarkerImage((ctx, s) => {
-        const cx = s / 2, cy = s / 2, outerR = s / 2 - 2, innerR = outerR * 0.4;
-        ctx.beginPath();
-        for (let i = 0; i < 10; i++) {
-          const r = i % 2 === 0 ? outerR : innerR;
-          const angle = (Math.PI / 2) * -1 + (Math.PI / 5) * i;
-          const x = cx + Math.cos(angle) * r;
-          const y = cy + Math.sin(angle) * r;
-          if (i === 0) ctx.moveTo(x, y);
-          else ctx.lineTo(x, y);
-        }
-        ctx.closePath();
-        ctx.fillStyle = "white";
-        ctx.fill();
-      }),
-      { sdf: true }
-    );
-
-    // Dot (Independent)
-    map.addImage(
-      "marker-independent",
-      createMarkerImage((ctx, s) => {
-        ctx.beginPath();
-        ctx.arc(s / 2, s / 2, s / 4, 0, Math.PI * 2);
-        ctx.fillStyle = "white";
-        ctx.fill();
-      }),
-      { sdf: true }
-    );
+    ensureMarkerIcons(map);
 
     // Fog / atmosphere
     map.setFog({
@@ -115,15 +104,17 @@ export default function useMapSetup(mapRef, resorts) {
     if (window.innerWidth < 640) {
       map.setPadding({ top: 0, right: 0, bottom: 80, left: 0 });
     }
-
-    setRenderedResorts(resorts);
-  }, [mapRef, resorts, setRenderedResorts]);
+  }, [mapRef]);
 
   const onStyleData = useCallback(() => {
     const mapWrapper = mapRef.current;
     if (!mapWrapper) return;
     const map = mapWrapper.getMap ? mapWrapper.getMap() : mapWrapper;
     if (!map.setFog) return;
+
+    // Re-add marker icons after style change
+    ensureMarkerIcons(map);
+
     const isDark = mapStyleKey === "dark" || mapStyleKey === "satellite";
     map.setFog({
       color: isDark ? "rgb(20, 20, 40)" : "rgb(186, 210, 235)",


### PR DESCRIPTION
## Problem
Resort markers disappear after flying to a resort (detail view) and don't reappear when navigating back to region view.

## Root Cause
SDF marker icons were only added in onMapLoad. When the map style rebuilds (satellite toggle, base map switch), icons are lost and symbol layers render nothing.

## Fix
- Extracted icon creation into ensureMarkerIcons() helper with hasImage() guard
- Called from both onMapLoad AND onStyleData so icons survive style changes
- Cleaned up stale setRenderedResorts() call (removed from Zustand store)
- Removed unused resorts param from useMapSetup hook

Closes #97