### PR TITLE
fix: mobile UX polish — back button, iOS search zoom, flyTo animations (#98)

### DIFF
--- a/src/app/components/MapControls.jsx
+++ b/src/app/components/MapControls.jsx
@@ -279,9 +279,9 @@ export default function MapControls({
         )}
       </div>
 
-      {/* ── Back button: mid-left on mobile (clear of carousel + search), bottom-left on desktop ── */}
+      {/* ── Back button: top-left on mobile (below regions+basemap), bottom-left on desktop ── */}
       {showBackButton && (
-        <div className="pointer-events-auto absolute left-3 bottom-[12.5rem] sm:bottom-3 sm:left-[calc(3rem+64px)]">
+        <div className="pointer-events-auto absolute left-3 top-[7.5rem] sm:top-auto sm:bottom-3 sm:left-[calc(3rem+64px)]">
           <button
             onClick={handleBack}
             className="flex items-center gap-1 rounded-full min-h-[44px] px-4 py-2.5 text-xs font-semibold backdrop-blur-md transition-all sm:min-h-0 sm:px-3 sm:py-1.5"

--- a/src/app/components/MobileCarousel.jsx
+++ b/src/app/components/MobileCarousel.jsx
@@ -121,7 +121,7 @@ function MobileSearchBar({ searchQuery, setSearchQuery }) {
               onChange={(e) => setSearchQuery(e.target.value)}
               onBlur={() => { if (!searchQuery) setExpanded(false); }}
               placeholder="Search resorts, locations..."
-              className="w-full rounded-full min-h-[44px] pl-10 pr-11 text-[13px] text-white placeholder-slate-500 outline-none bg-transparent tracking-wide"
+              className="w-full rounded-full min-h-[44px] pl-10 pr-11 text-base text-white placeholder-slate-500 outline-none bg-transparent tracking-wide"
             />
             <button
               onClick={() => { setSearchQuery(""); setExpanded(false); }}

--- a/src/app/components/ResultsContainer.jsx
+++ b/src/app/components/ResultsContainer.jsx
@@ -346,7 +346,7 @@ export function ResultsContainer({ resorts, setSelectedResort, selectedResort, n
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search resorts..."
-            className="w-full rounded-xl py-2.5 pl-9 pr-9 text-xs text-white placeholder-slate-500 outline-none transition-colors focus:ring-1 focus:ring-sky-500/40"
+            className="w-full rounded-xl py-2.5 pl-9 pr-9 text-base sm:text-xs text-white placeholder-slate-500 outline-none transition-colors focus:ring-1 focus:ring-sky-500/40"
             style={{ background: "rgba(255,255,255,0.08)", border: "1px solid rgba(255,255,255,0.12)" }}
           />
           {searchQuery && (

--- a/src/app/hooks/useMapNavigation.js
+++ b/src/app/hooks/useMapNavigation.js
@@ -51,7 +51,8 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
         zoom: cam ? cam.zoom : 14.5,
         pitch: cam ? cam.pitch : 72,
         bearing: cam ? cam.bearing : -30,
-        duration: 2500,
+        speed: 1.2,
+        curve: 1.8,
         essential: true,
       });
     },
@@ -68,7 +69,8 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
       zoom: 1.8,
       pitch: 0,
       bearing: 0,
-      duration: 1500,
+      speed: 0.8,
+      curve: 1.8,
       essential: true,
     });
     setSelectedResort(null);
@@ -94,6 +96,7 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
         pitch: 0,
         bearing: 0,
         duration: 1200,
+        curve: 1.5,
         essential: true,
       });
     },
@@ -135,7 +138,8 @@ export default function useMapNavigation(mapRef, stopSpin, nav) {
       zoom,
       pitch: 0,
       bearing: 0,
-      duration: 1500,
+      speed: 1.0,
+      curve: 1.6,
       essential: true,
     });
     setSelectedResort(null);


### PR DESCRIPTION
## Changes

### Fix 1: Back button positioning
Moved from `bottom-[12.5rem]` to `top-[7.5rem]` on mobile — sits below the regions dropdown and base map switcher on the left side. Clear of carousel, search, and filters. Desktop position unchanged.

### Fix 2: iOS Safari auto-zoom on search
- Mobile carousel search: `text-[13px]` → `text-base` (16px)
- Desktop sidebar search: `text-xs` → `text-base sm:text-xs` (16px on mobile, 12px on desktop)

iOS Safari auto-zooms when input font-size < 16px. This prevents that.

### Fix 3: flyTo animation polish
All `map.flyTo()` calls now use higher `curve` values for smoother arcs:
- **flyToResort**: `curve: 1.8, speed: 1.2` (was `duration: 2500`) — higher arc prevents ground-scraping
- **flyToRegion**: `curve: 1.6, speed: 1.0` (was `duration: 1500`) — smooth zoom-out
- **resetView**: `curve: 1.8, speed: 0.8` (was `duration: 1500`) — graceful pull-back
- **onRegionClick**: added `curve: 1.5` (kept `duration: 1200`)

Closes #98