### PR TITLE
feat: Globe view snowy region cards + always-rotate (#101)

### DIFF
--- a/assets/regions.json
+++ b/assets/regions.json
@@ -2,20 +2,20 @@
   {
     "id": "rocky-mountain",
     "label": "Rockies",
-    "emoji": "\u26f0\ufe0f",
+    "emoji": "⛰️",
     "center": [
       -110.5,
       45.5
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -115.0,
-        35.0
+        -115,
+        35
       ],
       [
-        -104.0,
-        52.0
+        -104,
+        52
       ]
     ],
     "countries": [
@@ -35,20 +35,20 @@
   {
     "id": "pnw",
     "label": "PNW",
-    "emoji": "\ud83c\udf32",
+    "emoji": "🌲",
     "center": [
       -121.7,
       46.8
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -125.0,
-        42.0
+        -125,
+        42
       ],
       [
-        -116.0,
-        50.0
+        -116,
+        50
       ]
     ],
     "countries": [
@@ -62,20 +62,20 @@
   {
     "id": "california",
     "label": "California",
-    "emoji": "\u2600\ufe0f",
+    "emoji": "☀️",
     "center": [
       -119.8,
-      38.0
+      38
     ],
-    "zoom": 7.5,
+    "zoom": 6,
     "bounds": [
       [
         -124.5,
-        32.0
+        32
       ],
       [
-        -114.0,
-        42.0
+        -114,
+        42
       ]
     ],
     "countries": [
@@ -89,20 +89,20 @@
   {
     "id": "northeast",
     "label": "Northeast",
-    "emoji": "\ud83c\udfd4\ufe0f",
+    "emoji": "🏔️",
     "center": [
-      -72.0,
-      44.0
+      -72,
+      44
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -80.0,
-        40.0
+        -80,
+        40
       ],
       [
-        -66.0,
-        48.0
+        -66,
+        48
       ]
     ],
     "countries": [
@@ -123,20 +123,20 @@
   {
     "id": "midwest",
     "label": "Midwest",
-    "emoji": "\ud83c\udf3e",
+    "emoji": "🌾",
     "center": [
-      -89.0,
-      45.0
+      -89,
+      45
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -96.0,
-        38.0
+        -96,
+        38
       ],
       [
-        -82.0,
-        49.0
+        -82,
+        49
       ]
     ],
     "countries": [
@@ -155,20 +155,20 @@
   {
     "id": "western-canada",
     "label": "W. Canada",
-    "emoji": "\ud83c\udf41",
+    "emoji": "🍁",
     "center": [
-      -117.0,
-      51.0
+      -117,
+      51
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -130.0,
-        48.0
+        -130,
+        48
       ],
       [
-        -110.0,
-        55.0
+        -110,
+        55
       ]
     ],
     "countries": [
@@ -182,20 +182,20 @@
   {
     "id": "eastern-canada",
     "label": "E. Canada",
-    "emoji": "\ud83c\udf41",
+    "emoji": "🍁",
     "center": [
-      -71.0,
-      47.0
+      -71,
+      47
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -80.0,
-        44.0
+        -80,
+        44
       ],
       [
-        -60.0,
-        52.0
+        -60,
+        52
       ]
     ],
     "countries": [
@@ -209,19 +209,19 @@
   {
     "id": "alps",
     "label": "Alps",
-    "emoji": "\ud83c\udfd4\ufe0f",
+    "emoji": "🏔️",
     "center": [
       10.5,
       46.8
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        5.0,
+        5,
         43.5
       ],
       [
-        17.0,
+        17,
         48.5
       ]
     ],
@@ -239,20 +239,20 @@
   {
     "id": "scandinavia",
     "label": "Scandinavia",
-    "emoji": "\u2744\ufe0f",
+    "emoji": "❄️",
     "center": [
-      14.0,
-      63.0
+      14,
+      63
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        4.0,
-        55.0
+        4,
+        55
       ],
       [
-        32.0,
-        72.0
+        32,
+        72
       ]
     ],
     "countries": [
@@ -264,20 +264,20 @@
   {
     "id": "japan",
     "label": "Japan",
-    "emoji": "\ud83d\uddfe",
+    "emoji": "🗾",
     "center": [
       138.5,
       36.8
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        128.0,
-        30.0
+        128,
+        30
       ],
       [
-        146.0,
-        46.0
+        146,
+        46
       ]
     ],
     "countries": [
@@ -287,20 +287,20 @@
   {
     "id": "oceania",
     "label": "Oceania",
-    "emoji": "\ud83c\udf0f",
+    "emoji": "🌏",
     "center": [
-      148.0,
-      -37.0
+      148,
+      -37
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        143.0,
-        -47.0
+        143,
+        -47
       ],
       [
-        175.0,
-        -34.0
+        175,
+        -34
       ]
     ],
     "countries": [
@@ -311,20 +311,20 @@
   {
     "id": "south-america",
     "label": "S. America",
-    "emoji": "\ud83c\udfd4\ufe0f",
+    "emoji": "🏔️",
     "center": [
-      -70.0,
-      -33.0
+      -70,
+      -33
     ],
-    "zoom": 7.0,
+    "zoom": 5.5,
     "bounds": [
       [
-        -75.0,
-        -55.0
+        -75,
+        -55
       ],
       [
-        -65.0,
-        -20.0
+        -65,
+        -20
       ]
     ],
     "countries": [

--- a/src/app/components/MapControls.jsx
+++ b/src/app/components/MapControls.jsx
@@ -52,10 +52,7 @@ const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_APIKEY;
  */
 export default function MapControls({
   mapRef,
-  spinning,
-  setSpinning,
   stopSpin,
-  setUserStopped,
   isResortView,
   resetView,
   flyToRegion,
@@ -138,15 +135,6 @@ export default function MapControls({
       flyToRegion();
     } else if (nav?.isRegion) {
       resetView();
-    }
-  };
-
-  const handleAutoRotate = () => {
-    if (spinning) {
-      stopSpin();
-    } else {
-      setUserStopped(false);
-      setSpinning(true);
     }
   };
 
@@ -327,24 +315,6 @@ export default function MapControls({
           </button>
         </div>
       )}
-
-      {/* ── Bottom-right: Auto-rotate toggle (above Mapbox zoom controls) ── */}
-      <div className="pointer-events-auto absolute bottom-[9rem] right-3 sm:bottom-[5rem]">
-        <button
-          onClick={handleAutoRotate}
-          className={`flex items-center justify-center rounded-full w-11 h-11 sm:w-9 sm:h-9 text-base sm:text-sm backdrop-blur-sm transition-all ${
-            spinning
-              ? "bg-sky-500/80 text-white shadow-lg shadow-sky-500/25 ring-1 ring-sky-400/40"
-              : "text-white/50 hover:text-white/80 border border-white/10"
-          }`}
-          style={{
-            background: spinning ? undefined : "rgba(15,23,42,0.8)",
-          }}
-          title={spinning ? "Stop auto-rotate" : "Start auto-rotate"}
-        >
-          ⟳
-        </button>
-      </div>
 
       {/* ── Bottom-right: Compass (resets bearing to north) ── */}
       {Math.abs(bearing) > 1 && (

--- a/src/app/components/RegionCard.jsx
+++ b/src/app/components/RegionCard.jsx
@@ -1,0 +1,72 @@
+"use client";
+import React from "react";
+
+/**
+ * RegionCard — shown in globe view (desktop sidebar + mobile carousel).
+ * Displays region snow summary; click navigates to that region.
+ */
+export function RegionCard({ region, onClick }) {
+  const snowDisplay = region.maxSnow > 0
+    ? `${Math.round(region.maxSnow * 0.393701)}"` // cm to inches
+    : "0\"";
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer rounded-xl p-3 transition-all border border-white/[0.08] hover:border-sky-400/40 hover:ring-1 hover:ring-sky-400/20 backdrop-blur-xl"
+      style={{ background: "rgba(15,23,42,0.88)" }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className="text-lg">{region.emoji}</span>
+        <h3 className="truncate text-sm font-bold text-white">{region.label}</h3>
+      </div>
+
+      {region.maxSnow > 0 && (
+        <div
+          className="flex items-center gap-2 mb-1.5 p-2 rounded-lg"
+          style={{ background: "rgba(14,165,233,0.1)", border: "1px solid rgba(14,165,233,0.15)" }}
+        >
+          <div className="text-center">
+            <div className="text-sm font-bold text-sky-300">❄️ {snowDisplay}</div>
+            <div className="text-[8px] text-sky-400/70 uppercase">this week</div>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-[10px] text-slate-400">
+        {region.topResort && (
+          <span className="truncate">Top: {region.topResort}</span>
+        )}
+        <span className="shrink-0 ml-2">{region.count} resort{region.count !== 1 ? "s" : ""}</span>
+      </div>
+    </div>
+  );
+}
+
+/** Compact version for mobile carousel */
+export function CompactRegionCard({ region, onClick }) {
+  const snowDisplay = region.maxSnow > 0
+    ? `${Math.round(region.maxSnow * 0.393701)}"`
+    : "0\"";
+
+  return (
+    <div
+      onClick={onClick}
+      className="snap-center shrink-0 w-44 max-h-[88px] rounded-xl p-2.5 cursor-pointer transition-all border border-white/10 hover:border-sky-400/40 bg-slate-900/90 backdrop-blur-xl overflow-hidden"
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <span className="text-sm">{region.emoji}</span>
+        <h3 className="truncate text-[11px] font-semibold text-white leading-tight">{region.label}</h3>
+      </div>
+
+      {region.maxSnow > 0 && (
+        <p className="text-[9px] font-semibold text-sky-300 mb-1">❄️ {snowDisplay} this week</p>
+      )}
+
+      <div className="flex items-center justify-between text-[9px] text-slate-400">
+        {region.topResort && <span className="truncate">Top: {region.topResort}</span>}
+        <span className="shrink-0 ml-1">{region.count}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/ResultsContainer.jsx
+++ b/src/app/components/ResultsContainer.jsx
@@ -2,6 +2,7 @@
 import React, { useRef, useEffect } from "react";
 import { getPercentile } from "../utils/percentiles";
 import useMapStore from "../store/useMapStore";
+import { RegionCard } from "./RegionCard";
 // zoom imports removed — nav state drives UI now
 
 const PASS_COLORS_HEX = {
@@ -301,15 +302,35 @@ function ResortCard({ resort, isSelected, isHighlighted, onClick }) {
   );
 }
 
-export function ResultsContainer({ resorts, setSelectedResort, selectedResort, nav }) {
+export function ResultsContainer({ resorts, setSelectedResort, selectedResort, nav, regionSummaries, onRegionCardClick }) {
   const searchQuery = useMapStore((s) => s.searchQuery);
   const setSearchQuery = useMapStore((s) => s.setSearchQuery);
   const highlightedSlug = useMapStore((s) => s.highlightedSlug);
   const snowBySlug = useMapStore((s) => s.snowBySlug);
   const isDetailView = nav?.isResort || false;
 
-  // Hide results at globe zoom — users pick a region first
+  // Globe view — show region summary cards
   if (nav?.isGlobe && !selectedResort) {
+    if (regionSummaries?.length > 0) {
+      return (
+        <div className="flex flex-col h-full">
+          <div className="sticky top-0 z-10 p-2.5" style={{ background: "rgba(15,23,42,0.95)", backdropFilter: "blur(12px)" }}>
+            <div className="text-[10px] text-slate-500 px-1">
+              {regionSummaries.length} region{regionSummaries.length !== 1 ? "s" : ""} · select one to explore
+            </div>
+          </div>
+          <div className="flex flex-col gap-2 overflow-auto px-2 py-1 flex-1">
+            {regionSummaries.map((region) => (
+              <RegionCard
+                key={region.regionId}
+                region={region}
+                onClick={() => onRegionCardClick(region.regionId)}
+              />
+            ))}
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="flex flex-col h-full items-center justify-center text-center px-6">
         <div className="text-3xl mb-3">🌍</div>

--- a/src/app/hooks/useGlobeSpin.js
+++ b/src/app/hooks/useGlobeSpin.js
@@ -3,57 +3,61 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 
 /**
- * useGlobeSpin — manages auto-rotation of the globe at low zoom.
- * Spins eastward at 0.8°/frame, pauses on user interaction,
- * resumes after 5s idle (unless user explicitly stopped).
+ * useGlobeSpin — auto-rotates globe when in globe view.
+ * Always spins at globe view; stops on user interaction;
+ * resumes after 5s idle. No toggle button needed.
  */
-export default function useGlobeSpin(mapRef) {
+export default function useGlobeSpin(mapRef, isGlobe) {
   const spinTimerRef = useRef(null);
   const idleTimerRef = useRef(null);
   const [spinning, setSpinning] = useState(true);
-  const [userStopped, setUserStopped] = useState(false);
+  const [userPaused, setUserPaused] = useState(false);
   const spinningRef = useRef(spinning);
 
   useEffect(() => {
     spinningRef.current = spinning;
   }, [spinning]);
 
-  // Start/stop spin interval
+  // When nav leaves globe, stop. When returning to globe, resume.
   useEffect(() => {
-    if (!spinning || userStopped) return;
+    if (isGlobe) {
+      setUserPaused(false);
+      setSpinning(true);
+    } else {
+      setSpinning(false);
+      clearTimeout(idleTimerRef.current);
+    }
+  }, [isGlobe]);
+
+  // Run spin interval
+  useEffect(() => {
+    if (!spinning || !isGlobe) return;
     spinTimerRef.current = setInterval(() => {
       const map = mapRef.current;
       if (!map) return;
-      if (map.getZoom() < 3.5) {
-        const center = map.getCenter();
-        center.lng += 0.8;
-        map.easeTo({ center, duration: 50, easing: (t) => t });
-      }
+      const center = map.getCenter();
+      center.lng += 0.8;
+      map.easeTo({ center, duration: 50, easing: (t) => t });
     }, 50);
     return () => clearInterval(spinTimerRef.current);
-  }, [spinning, userStopped, mapRef]);
+  }, [spinning, isGlobe, mapRef]);
 
+  // Stop spin on user interaction (called from map onMouseDown/onTouchStart)
   const stopSpin = useCallback(() => {
     setSpinning(false);
-    setUserStopped(true);
+    setUserPaused(true);
     clearTimeout(idleTimerRef.current);
-  }, []);
-
-  const resumeSpinAfterIdle = useCallback(() => {
-    if (userStopped) return;
-    clearTimeout(idleTimerRef.current);
+    // Resume after 5s if still in globe view
     idleTimerRef.current = setTimeout(() => {
+      setUserPaused(false);
       setSpinning(true);
     }, 5000);
-  }, [userStopped]);
+  }, []);
 
   return {
     spinning,
     setSpinning,
     spinningRef,
-    userStopped,
-    setUserStopped,
     stopSpin,
-    resumeSpinAfterIdle,
   };
 }

--- a/src/app/store/useMapStore.js
+++ b/src/app/store/useMapStore.js
@@ -39,6 +39,10 @@ const useMapStore = create(
       navRegion: null,
       setNavRegion: (r) => set({ navRegion: r }),
 
+      // ── Pending region fly (set by region card click, consumed by MapExplore) ──
+      pendingRegionFly: null,
+      setPendingRegionFly: (id) => set({ pendingRegionFly: id }),
+
       // ── 3D terrain / fly-to state ──
       previousViewState: null,
       setPreviousViewState: (vs) => set({ previousViewState: vs }),


### PR DESCRIPTION
## Changes

### Task 1: Snowy Region Cards at Globe View
- Compute region snow summaries in `page.js` when `nav.isGlobe` — aggregates max 7-day snowfall, top resort, and resort count per region
- New `RegionCard` (desktop) and `CompactRegionCard` (mobile) components matching existing frosted glass card style
- `ResultsContainer` shows region cards sorted by snowfall instead of empty "select a region" state
- `MobileCarousel` shows compact region cards in horizontal scroll at globe view
- Card click → `nav.goToRegion(id)` + `pendingRegionFly` in Zustand → MapExplore flies to region

### Task 2: Always-Rotate Globe
- `useGlobeSpin` now takes `isGlobe` param — auto-rotates when globe view, stops when navigating away
- Resumes spin on return to globe; pauses on user interaction with 5s idle resume
- Removed ⟳ auto-rotate toggle button from `MapControls`
- Cleaned up unused props (`spinning`, `setSpinning`, `setUserStopped`)

### Build
`npm run build` passes ✅